### PR TITLE
Usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,7 @@ dependencies = [
  "itoa",
  "pq-sys",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2131,6 +2138,8 @@ dependencies = [
  "thiserror",
  "time",
  "time-tz",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2554,11 +2563,26 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
+ "atomic",
  "getrandom",
+ "rand",
+ "serde",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abb14ae1a50dad63eaa768a458ef43d298cd1bd44951677bd10b732a9ba2a2d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2", features = ["postgres", "time" ] }
+diesel = { version = "2", features = ["postgres", "time", "uuid" ] }
 diesel-async = { version = "0.4", features = ["postgres", "deadpool" ] }
 scoped-futures = "0.1"
 diesel_migrations = "2"

--- a/diesel/migrations/2024-01-23-170835_usage/down.sql
+++ b/diesel/migrations/2024-01-23-170835_usage/down.sql
@@ -1,0 +1,10 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE "usages";
+
+ALTER TABLE "public"."parts"
+  DROP COLUMN "usage",
+  ADD COLUMN "time" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "distance" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "climb" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "descend" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "count" integer NOT NULL DEFAULT '0';

--- a/diesel/migrations/2024-01-23-170835_usage/down.sql
+++ b/diesel/migrations/2024-01-23-170835_usage/down.sql
@@ -8,3 +8,11 @@ ALTER TABLE "public"."parts"
   ADD COLUMN "climb" integer NOT NULL DEFAULT '0',
   ADD COLUMN "descend" integer NOT NULL DEFAULT '0',
   ADD COLUMN "count" integer NOT NULL DEFAULT '0';
+
+ALTER TABLE "public"."attachments"
+  DROP COLUMN "usage",
+  ADD COLUMN "time" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "distance" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "climb" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "descend" integer NOT NULL DEFAULT '0',
+  ADD COLUMN "count" integer NOT NULL DEFAULT '0';

--- a/diesel/migrations/2024-01-23-170835_usage/up.sql
+++ b/diesel/migrations/2024-01-23-170835_usage/up.sql
@@ -14,4 +14,12 @@ ALTER TABLE "public"."parts"
   DROP COLUMN "climb",
   DROP COLUMN "descend",
   DROP COLUMN "count",
-  ADD COLUMN "usage" uuid;
+  ADD COLUMN "usage" uuid NOT NULL DEFAULT gen_random_uuid();
+
+ALTER TABLE "public"."attachments"
+  DROP COLUMN "time",
+  DROP COLUMN "distance",
+  DROP COLUMN "climb",
+  DROP COLUMN "descend",
+  DROP COLUMN "count",
+  ADD COLUMN "usage" uuid NOT NULL DEFAULT gen_random_uuid();

--- a/diesel/migrations/2024-01-23-170835_usage/up.sql
+++ b/diesel/migrations/2024-01-23-170835_usage/up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE usages (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    time integer,
+    distance integer,
+    climb integer,
+    descend integer,
+    power integer,
+    count integer
+);
+
+ALTER TABLE "public"."parts"
+  DROP COLUMN "time",
+  DROP COLUMN "distance",
+  DROP COLUMN "climb",
+  DROP COLUMN "descend",
+  DROP COLUMN "count",
+  ADD COLUMN "usage" uuid;

--- a/diesel/src/store/activity.rs
+++ b/diesel/src/store/activity.rs
@@ -105,19 +105,20 @@ impl tb_domain::ActivityStore for AsyncDieselConn {
     }
 
     async fn part_reset_all(&mut self) -> TbResult<usize> {
-        use schema::parts::dsl::*;
-        debug!("resetting all parts");
-        diesel::update(parts)
-            .set((
-                time.eq(0),
-                distance.eq(0),
-                climb.eq(0),
-                descend.eq(0),
-                count.eq(0),
-            ))
-            .execute(self)
-            .await
-            .map_err(map_to_tb)
+        todo!();
+        // use schema::parts::dsl::*;
+        // debug!("resetting all parts");
+        // diesel::update(parts)
+        //     .set((
+        //         time.eq(0),
+        //         distance.eq(0),
+        //         climb.eq(0),
+        //         descend.eq(0),
+        //         count.eq(0),
+        //     ))
+        //     .execute(self)
+        //     .await
+        //     .map_err(map_to_tb)
     }
 
     async fn activity_get_really_all(&mut self) -> TbResult<Vec<Activity>> {

--- a/diesel/src/store/activity.rs
+++ b/diesel/src/store/activity.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use async_session::log::debug;
+// use async_session::log::debug;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use tb_domain::schema;
@@ -102,23 +102,6 @@ impl tb_domain::ActivityStore for AsyncDieselConn {
             .get_results::<Activity>(self)
             .await
             .map_err(map_to_tb)
-    }
-
-    async fn part_reset_all(&mut self) -> TbResult<usize> {
-        todo!();
-        // use schema::parts::dsl::*;
-        // debug!("resetting all parts");
-        // diesel::update(parts)
-        //     .set((
-        //         time.eq(0),
-        //         distance.eq(0),
-        //         climb.eq(0),
-        //         descend.eq(0),
-        //         count.eq(0),
-        //     ))
-        //     .execute(self)
-        //     .await
-        //     .map_err(map_to_tb)
     }
 
     async fn activity_get_really_all(&mut self) -> TbResult<Vec<Activity>> {

--- a/diesel/src/store/mod.rs
+++ b/diesel/src/store/mod.rs
@@ -6,6 +6,7 @@ mod activity;
 mod attachment;
 mod part;
 mod types;
+mod usage;
 mod user;
 
 #[async_session::async_trait]

--- a/diesel/src/store/part.rs
+++ b/diesel/src/store/part.rs
@@ -7,14 +7,10 @@ use diesel_async::RunQueryDsl;
 use tb_domain::schema;
 use tb_domain::Part;
 use tb_domain::PartId;
-use tb_domain::Person;
 use tb_domain::TbResult;
-use tb_domain::Usage;
 use tb_domain::UsageId;
 use tb_domain::UserId;
 use time::OffsetDateTime;
-
-use tb_domain::PartTypeId;
 
 #[async_session::async_trait]
 impl tb_domain::PartStore for AsyncDieselConn {
@@ -25,67 +21,6 @@ impl tb_domain::PartStore for AsyncDieselConn {
             .first::<Part>(self)
             .await
             .map_err(map_to_tb)
-    }
-
-    async fn partid_get_name(&mut self, pid: PartId) -> TbResult<String> {
-        use schema::parts;
-        parts::table
-            .find(pid)
-            .select(parts::name)
-            .first(self)
-            .await
-            .map_err(map_to_tb)
-    }
-
-    async fn partid_get_type(&mut self, pid: PartId) -> TbResult<PartTypeId> {
-        use schema::parts;
-        parts::table
-            .find(pid)
-            .select(parts::what)
-            .first(self)
-            .await
-            .map_err(map_to_tb)
-    }
-
-    async fn partid_get_ownerid(&mut self, pid: PartId, user: &dyn Person) -> TbResult<UserId> {
-        use schema::parts::dsl::*;
-        parts
-            .find(pid)
-            .filter(owner.eq(user.get_id()))
-            .select(owner)
-            .first::<UserId>(self)
-            .await
-            .map_err(Into::into)
-    }
-
-    async fn partid_apply_usage(
-        &mut self,
-        pid: PartId,
-        usage: &Usage,
-        start: OffsetDateTime,
-    ) -> TbResult<Part> {
-        todo!();
-        // use schema::parts::dsl::*;
-        // Ok(self
-        //     .transaction(|conn| {
-        //         async {
-        //             let part: Part = parts.find(pid).for_update().get_result(conn).await?;
-        //             diesel::update(parts.find(pid))
-        //                 .set((
-        //                     time.eq(time + usage.time),
-        //                     climb.eq(climb + usage.climb),
-        //                     descend.eq(descend + usage.descend),
-        //                     distance.eq(distance + usage.distance),
-        //                     count.eq(count + usage.count),
-        //                     purchase.eq(std::cmp::min(part.purchase, start)),
-        //                     last_used.eq(std::cmp::max(part.last_used, start)),
-        //                 ))
-        //                 .get_result::<Part>(conn)
-        //                 .await
-        //         }
-        //         .scope_boxed()
-        //     })
-        //     .await?)
     }
 
     async fn part_get_all_for_userid(&mut self, uid: &UserId) -> TbResult<Vec<Part>> {
@@ -99,7 +34,7 @@ impl tb_domain::PartStore for AsyncDieselConn {
             .map_err(map_to_tb)
     }
 
-    async fn create_part(
+    async fn part_create(
         &mut self,
         newpart: tb_domain::NewPart,
         createtime: OffsetDateTime,
@@ -120,6 +55,15 @@ impl tb_domain::PartStore for AsyncDieselConn {
         diesel::insert_into(parts)
             .values(values)
             .get_result(self)
+            .await
+            .map_err(map_to_tb)
+    }
+
+    async fn part_update(&mut self, part: &Part) -> TbResult<usize> {
+        use schema::parts::dsl::*;
+        diesel::update(parts.filter(id.eq(part.id)))
+            .set(part)
+            .execute(self)
             .await
             .map_err(map_to_tb)
     }

--- a/diesel/src/store/usage.rs
+++ b/diesel/src/store/usage.rs
@@ -1,0 +1,57 @@
+use crate::*;
+use async_session::log::debug;
+use diesel::QueryDsl;
+use diesel_async::AsyncConnection;
+use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt;
+use tb_domain::{TbResult, Usage, UsageId, UsageStore};
+
+#[async_session::async_trait]
+impl UsageStore for AsyncDieselConn {
+    async fn usage_get(&mut self, id: UsageId) -> TbResult<Usage> {
+        use schema::usages;
+        match usages::table
+            .find(usages::id)
+            .get_result::<Usage>(self)
+            .await
+        {
+            Ok(x) => Ok(x),
+            Err(diesel::NotFound) => Ok(Usage {
+                id,
+                ..Default::default()
+            }),
+            Err(x) => Err(map_to_tb(x)),
+        }
+    }
+
+    async fn usage_update(&mut self, vec: Vec<&Usage>) -> TbResult<usize> {
+        use schema::usages;
+
+        let len = vec.len();
+        self.transaction(|conn| {
+            async move {
+                for usage in vec {
+                    diesel::insert_into(usages::table)
+                        .values(usage)
+                        .on_conflict(usages::id)
+                        .do_update()
+                        .set(usage)
+                        .execute(conn)
+                        .await?;
+                }
+                Ok(len)
+            }
+            .scope_boxed()
+        })
+        .await
+    }
+
+    async fn usage_reset_all(&mut self) -> TbResult<usize> {
+        use schema::usages::dsl::*;
+        debug!("resetting all usages");
+        diesel::delete(usages)
+            .execute(self)
+            .await
+            .map_err(map_to_tb)
+    }
+}

--- a/diesel/src/store/usage.rs
+++ b/diesel/src/store/usage.rs
@@ -48,9 +48,12 @@ impl UsageStore for AsyncDieselConn {
         .await
     }
 
-    async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<usize> {
+    async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<Usage> {
         use schema::usages::dsl::*;
-        Ok(diesel::delete(usages.find(usage)).execute(self).await?)
+        diesel::delete(usages.find(usage))
+            .get_result(self)
+            .await
+            .map_err(map_to_tb)
     }
 
     async fn usage_reset_all(&mut self) -> TbResult<usize> {

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -24,3 +24,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 
 async-trait = "0.1"
+uuid = { version = "1.7.0", features = ["v7", "fast-rng", "macro-diagnostics", "serde"] }
+
+[dev-dependencies]
+tokio = { version = "1",  features = ["macros", "rt"]}

--- a/domain/src/entities/activity.rs
+++ b/domain/src/entities/activity.rs
@@ -296,10 +296,11 @@ impl Activity {
         let mut parts = Vec::new();
         let mut usages = Vec::new();
         for part in partlist {
-            parts.push(part.update_last_use(self.start, store).await?);
-            usages.push(part.apply_usage(&usage, store).await?);
+            let part = part.update_last_use(self.start, store).await?;
+            usages.push(part.usage(store).await? + &usage);
+            parts.push(part);
         }
-        usages.append(&mut Attachment::register(&self, &usage, store).await?);
+        usages.append(&mut Attachment::apply_usage(&self, &usage, store).await?);
         Usage::update_vec(&usages, store).await?;
         Ok(Summary {
             usages,

--- a/domain/src/entities/activity.rs
+++ b/domain/src/entities/activity.rs
@@ -429,7 +429,7 @@ impl Activity {
 }
 
 async fn rescan(conn: &mut impl Store) -> TbResult<()> {
-    conn.part_reset_all().await?;
+    conn.usage_reset_all().await?;
     conn.attachment_reset_all().await?;
     for a in conn.activity_get_really_all().await? {
         debug!("registering activity {}", a.id);

--- a/domain/src/entities/activity.rs
+++ b/domain/src/entities/activity.rs
@@ -247,6 +247,7 @@ impl Activity {
     /// Account for Factor
     pub(crate) fn usage(&self) -> Usage {
         Usage {
+            id: UsageId::default(),
             time: self.time.unwrap_or(0),
             distance: self.distance.unwrap_or(0),
             climb: self.climb.unwrap_or(0),

--- a/domain/src/entities/attachment/event.rs
+++ b/domain/src/entities/attachment/event.rs
@@ -5,6 +5,7 @@ use time::OffsetDateTime;
 
 use crate::{
     traits::Store, Attachment, Error, PartId, PartTypeId, Person, SumHash, Summary, TbResult,
+    UsageId,
 };
 
 const MAX_TIME: OffsetDateTime = time::macros::datetime!(9100-01-01 0:00 UTC);
@@ -241,11 +242,7 @@ impl Event {
             hook: self.hook,
             attached: self.time,
             detached,
-            count: 0,
-            time: 0,
-            climb: 0,
-            descend: 0,
-            distance: 0,
+            usage: UsageId::new(),
         }
     }
 

--- a/domain/src/entities/attachment/mod.rs
+++ b/domain/src/entities/attachment/mod.rs
@@ -108,7 +108,7 @@ impl Attachment {
             Activity::find(self.gear, self.attached, self.detached, conn)
                 .await?
                 .into_iter()
-                .fold(Usage::default(), |usage, act| usage + act.usage()),
+                .fold(Usage::default(), |usage, act| &usage + &act.usage()),
         )
     }
 

--- a/domain/src/entities/attachment/mod.rs
+++ b/domain/src/entities/attachment/mod.rs
@@ -70,16 +70,7 @@ pub struct Attachment {
     #[serde(with = "time::serde::rfc3339")]
     detached: OffsetDateTime,
     // we do not accept theses values from the client!
-    /// usage count
-    pub count: i32,
-    /// usage time
-    pub time: i32,
-    /// Usage distance
-    pub distance: i32,
-    /// Overall climbing
-    pub climb: i32,
-    /// Overall descending
-    pub descend: i32,
+    usage: UsageId,
 }
 /// Attachment with additional details
 ///
@@ -89,7 +80,7 @@ pub struct Attachment {
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 pub struct AttachmentDetail {
     #[serde(flatten)]
-    a: Attachment,
+    pub a: Attachment,
     name: String,
     what: PartTypeId,
 }
@@ -102,14 +93,18 @@ impl AttachmentDetail {
 }
 
 impl Attachment {
-    /// return the usage for the attachment
-    async fn usage(&self, conn: &mut impl Store) -> TbResult<Usage> {
+    /// return the calculated usage for the attachment
+    async fn calculate_usage(&self, conn: &mut impl Store) -> TbResult<Usage> {
         Ok(
             Activity::find(self.gear, self.attached, self.detached, conn)
                 .await?
                 .into_iter()
-                .fold(Usage::default(), |usage, act| &usage + &act.usage()),
+                .fold(Usage::new(self.usage), |usage, act| usage + &act.usage()),
         )
+    }
+
+    pub(crate) async fn usage(&self, store: &mut impl Store) -> TbResult<Usage> {
+        self.usage.read(store).await
     }
 
     async fn shift(
@@ -152,20 +147,14 @@ impl Attachment {
     //
     /// - recalculates the usage counters in the attached assembly
     /// - returns all affected parts
-    async fn create(mut self, conn: &mut impl Store) -> TbResult<Summary> {
+    async fn create(mut self, store: &mut impl Store) -> TbResult<Summary> {
         trace!("create {:?}", self);
-        let usage = self.usage(conn).await?;
-        self.count = usage.count;
-        self.time = usage.time;
-        self.distance = usage.distance;
-        self.climb = usage.climb;
-        self.descend = usage.descend;
-        let part = self
-            .part_id
-            .apply_usage(&usage, self.attached, conn)
-            .await?;
-
-        let attachment = conn
+        let part = self.part_id.update_last_use(self.attached, store).await?;
+        self.usage = UsageId::new();
+        let usage = self.calculate_usage(store).await?;
+        let part_usage = self.part_id.apply_usage(&usage, store).await?;
+        Usage::update_vec(&vec![&usage, &part_usage], store).await?;
+        let attachment = store
             .attachment_create(self)
             .await?
             .add_details(&part.name, part.what);
@@ -173,6 +162,7 @@ impl Attachment {
         Ok(Summary {
             parts: vec![part],
             attachments: vec![attachment],
+            usages: vec![usage, part_usage],
             ..Default::default()
         })
     }
@@ -181,24 +171,23 @@ impl Attachment {
     ///
     /// - recalculates the usage counters in the attached assembly
     /// - returns all affected parts
-    async fn delete(self, conn: &mut impl Store) -> TbResult<Summary> {
+    async fn delete(self, store: &mut impl Store) -> TbResult<Summary> {
         trace!("delete {:?}", self);
-        let mut att = conn.attachment_delete(self).await?;
+        let att = store.attachment_delete(self).await?;
 
-        let usage = -att.usage(conn).await?;
-        let part = att.part_id.apply_usage(&usage, att.attached, conn).await?;
-        att.count = 0;
-        att.time = 0;
-        att.distance = 0;
-        att.climb = 0;
-        att.descend = 0;
+        let usage = -att.calculate_usage(store).await?;
+        let usages = vec![att.part_id.apply_usage(&usage, store).await?];
+        Usage::update_vec(&usages, store).await?;
 
+        att.usage.delete(store).await?;
+        let mut att = att;
         // mark as deleted for client!
         att.detached = att.attached;
+        att.usage = UsageId::new();
         Ok(Summary {
             attachments: vec![att.add_details("", 0.into())],
-            parts: vec![part],
-            activities: vec![],
+            usages,
+            ..Default::default()
         })
     }
 
@@ -244,20 +233,16 @@ impl Attachment {
     pub(crate) async fn register(
         act: &Activity,
         usage: &Usage,
-        conn: &mut impl Store,
-    ) -> TbResult<Vec<AttachmentDetail>> {
+        store: &mut impl Store,
+    ) -> TbResult<Vec<Usage>> {
         let mut res = Vec::new();
         if let Some(act_gear) = act.gear {
             let start = act.start;
-            let atts = conn
-                .attachments_add_usage_by_gear_and_time(act_gear, start, usage)
+            let atts = store
+                .attachment_get_by_gear_and_time(act_gear, start)
                 .await?;
             for att in atts.iter() {
-                res.push(
-                    att.read_details(conn)
-                        .await
-                        .expect("couldn't enrich attachment"),
-                );
+                res.push(att.usage(store).await? + usage);
             }
         }
         Ok(res)

--- a/domain/src/entities/summary.rs
+++ b/domain/src/entities/summary.rs
@@ -19,6 +19,7 @@ pub struct Summary {
     pub activities: Vec<Activity>,
     pub parts: Vec<Part>,
     pub attachments: Vec<AttachmentDetail>,
+    pub usages: Vec<Usage>,
 }
 
 impl Summary {
@@ -26,11 +27,13 @@ impl Summary {
         activities: Vec<entities::activity::Activity>,
         parts: Vec<Part>,
         attachments: Vec<AttachmentDetail>,
+        usages: Vec<Usage>,
     ) -> Self {
         Summary {
             activities,
             parts,
             attachments,
+            usages,
         }
     }
 
@@ -38,6 +41,7 @@ impl Summary {
         self.activities.append(&mut new.activities);
         self.parts.append(&mut new.parts);
         self.attachments.append(&mut new.attachments);
+        self.usages.append(&mut new.usages);
     }
 
     pub fn merge(self, new: Summary) -> Summary {
@@ -56,6 +60,7 @@ pub struct SumHash {
     activities: HashMap<ActivityId, Activity>,
     parts: HashMap<PartId, Part>,
     atts: HashMap<String, AttachmentDetail>,
+    uses: HashMap<UsageId, Usage>,
 }
 
 impl SumHash {
@@ -75,6 +80,9 @@ impl SumHash {
         for att in ps.attachments {
             self.atts.insert(att.idx(), att);
         }
+        for usage in ps.usages {
+            self.uses.insert(usage.id, usage);
+        }
     }
 
     pub fn collect(self) -> Summary {
@@ -82,6 +90,7 @@ impl SumHash {
             activities: self.activities.into_values().collect(),
             parts: self.parts.into_values().collect(),
             attachments: self.atts.into_values().collect(),
+            usages: self.uses.into_values().collect(),
         }
     }
 }

--- a/domain/src/entities/usage.rs
+++ b/domain/src/entities/usage.rs
@@ -22,11 +22,29 @@
 //! The `Usage` struct represents the usage of a part, including time, distance, climbing, descending, power, and count.
 //! It also provides methods to add an activity to the usage.
 
+use super::*;
+use crate::schema::*;
+use crate::UsageStore;
+use diesel_derive_newtype::*;
+use newtype_derive::*;
 use serde_derive::{Deserialize, Serialize};
-use std::ops::{Add, Neg};
+use std::ops::{Add, Neg, Sub};
+use uuid::Uuid;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(
+    DieselNewType, Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, Default,
+)]
+pub struct UsageId(Uuid);
+
+NewtypeDisplay! { () pub struct UsageId(); }
+NewtypeFrom! { () pub struct UsageId(Uuid); }
+
+#[derive(
+    Clone, Debug, PartialEq, Default, Serialize, Deserialize, Queryable, Identifiable, AsChangeset,
+)]
 pub struct Usage {
+    // id for referencing
+    pub id: UsageId,
     // usage time
     pub time: i32,
     /// Usage distance
@@ -41,19 +59,61 @@ pub struct Usage {
     pub count: i32,
 }
 
+impl Usage {
+    pub(crate) async fn create(store: &mut impl UsageStore) -> TbResult<Usage> {
+        let res = Usage {
+            id: Uuid::now_v7().into(),
+            ..Default::default()
+        };
+        return store.create(&res).await.map(|_| res);
+    }
+
+    pub(crate) async fn update_vec(
+        vec: Vec<&Self>,
+        store: &mut impl UsageStore,
+    ) -> TbResult<usize> {
+        return store.update(vec).await;
+    }
+}
+
+impl UsageId {
+    pub(crate) async fn read(self, store: &mut impl UsageStore) -> TbResult<Usage> {
+        return store.read(self).await;
+    }
+}
+
 impl Add for Usage {
     type Output = Self;
     /// Add an activity to of a usage
     ///
     /// If the descend value is missing, assume descend = climb
-    fn add(self, act: Self) -> Self {
+    fn add(self, rhs: Self) -> Self {
         Usage {
-            time: self.time + act.time,
-            climb: self.climb + act.climb,
-            descend: self.descend + act.descend,
-            power: self.power + act.power,
-            distance: self.distance + act.distance,
-            count: self.count + act.count,
+            id: self.id,
+            time: self.time + rhs.time,
+            climb: self.climb + rhs.climb,
+            descend: self.descend + rhs.descend,
+            power: self.power + rhs.power,
+            distance: self.distance + rhs.distance,
+            count: self.count + rhs.count,
+        }
+    }
+}
+
+impl Sub for Usage {
+    type Output = Self;
+    /// Add an activity to of a usage
+    ///
+    /// If the descend value is missing, assume descend = climb
+    fn sub(self, rhs: Self) -> Self {
+        Usage {
+            id: self.id,
+            time: self.time - rhs.time,
+            climb: self.climb - rhs.climb,
+            descend: self.descend - rhs.descend,
+            power: self.power - rhs.power,
+            distance: self.distance - rhs.distance,
+            count: self.count - rhs.count,
         }
     }
 }
@@ -63,6 +123,7 @@ impl Neg for Usage {
 
     fn neg(self) -> Self::Output {
         Usage {
+            id: self.id,
             time: -self.time,
             climb: -self.climb,
             descend: -self.descend,
@@ -70,5 +131,72 @@ impl Neg for Usage {
             distance: -self.distance,
             count: -self.count,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::collections::HashMap;
+
+    use crate::{Error, TbResult, Usage, UsageId, UsageStore};
+
+    struct MemStore(std::collections::HashMap<UsageId, Usage>);
+
+    #[async_session::async_trait]
+    impl UsageStore for MemStore {
+        async fn read(&mut self, uid: UsageId) -> TbResult<Usage> {
+            self.0
+                .get(&uid)
+                .ok_or(Error::NotFound(format!("UsageId {uid} not found")))
+                .map(|u| u.clone())
+        }
+
+        async fn create(&mut self, usage: &Usage) -> TbResult<usize> {
+            if self.0.contains_key(&usage.id) {
+                return Err(Error::Conflict(format!(
+                    "UsageId {} does already exist",
+                    usage.id
+                )));
+            }
+
+            self.0.insert(usage.id, usage.clone());
+            return Ok(1);
+        }
+
+        async fn update(&mut self, vec: Vec<&Usage>) -> TbResult<usize> {
+            for usage in &vec {
+                if self.0.insert(usage.id, (*usage).clone()) == None {
+                    return Err(Error::Conflict(format!(
+                        "UsageId {} does not exist",
+                        usage.id
+                    )));
+                }
+            }
+            return Ok(vec.len());
+        }
+    }
+
+    #[tokio::test]
+    async fn create_usage_returns() -> TbResult<()> {
+        let mut store = MemStore(HashMap::new());
+        let usage = Usage::create(&mut store).await?;
+        assert_eq!(usage.climb, 0);
+        let usage2 = Usage {
+            count: 1,
+            climb: 2,
+            descend: 3,
+            ..Default::default()
+        };
+        let usage3 = usage.clone() + usage2.clone() + usage2;
+        assert_eq!((&usage3).climb, 4);
+        assert_eq!((&usage3).count, 2);
+        assert_eq!((&usage3).descend, 6);
+        assert_eq!((&usage3).time, 0);
+        Usage::update_vec(vec![&usage3], &mut store).await?;
+        let usage4 = usage3.id.read(&mut store).await?;
+        assert_eq!(usage3, usage4);
+        assert_eq!(usage4 - usage3, usage);
+        Ok(())
     }
 }

--- a/domain/src/entities/usage.rs
+++ b/domain/src/entities/usage.rs
@@ -90,7 +90,7 @@ impl UsageId {
         Uuid::now_v7().into()
     }
 
-    pub(crate) async fn delete(self, store: &mut impl UsageStore) -> TbResult<usize> {
+    pub(crate) async fn delete(self, store: &mut impl UsageStore) -> TbResult<Usage> {
         store.usage_delete(&self).await
     }
 
@@ -195,9 +195,9 @@ mod tests {
             Ok(vec.len())
         }
 
-        async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<usize> {
+        async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<Usage> {
             match self.0.remove(&usage) {
-                Some(_) => Ok(1),
+                Some(x) => Ok(x),
                 None => Err(crate::Error::NotFound(format!("Usage {} not found", usage))),
             }
         }

--- a/domain/src/schema.rs
+++ b/domain/src/schema.rs
@@ -32,11 +32,7 @@ table! {
         gear -> Int4,
         hook -> Int4,
         detached -> Timestamptz,
-        count -> Int4,
-        time -> Int4,
-        distance -> Int4,
-        climb -> Int4,
-        descend -> Int4,
+        usage -> Uuid,
     }
 }
 

--- a/domain/src/schema.rs
+++ b/domain/src/schema.rs
@@ -60,13 +60,26 @@ table! {
         vendor -> Text,
         model -> Text,
         purchase -> Timestamptz,
-        time -> Int4,
-        distance -> Int4,
-        climb -> Int4,
-        descend -> Int4,
-        count -> Int4,
         last_used -> Timestamptz,
         disposed_at -> Nullable<Timestamptz>,
+        usage -> Uuid,
+    }
+}
+
+table! {
+    usages(id) {
+        id -> Uuid,
+        time -> Int4,
+        /// Usage distance
+        distance -> Int4,
+        /// Overall climbing
+        climb -> Int4,
+        /// Overall descending
+        descend -> Int4,
+        /// Overall descending
+        power -> Int4,
+        /// number of activities
+        count -> Int4,
     }
 }
 

--- a/domain/src/traits/activity.rs
+++ b/domain/src/traits/activity.rs
@@ -113,13 +113,6 @@ pub trait ActivityStore {
         partid: &PartId,
     ) -> TbResult<Vec<Activity>>;
 
-    /// Resets all parts.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` containing the number of reset parts or an error if the operation fails.
-    async fn part_reset_all(&mut self) -> TbResult<usize>;
-
     /// Retrieves all activities.
     ///
     /// # Returns

--- a/domain/src/traits/attachment.rs
+++ b/domain/src/traits/attachment.rs
@@ -1,6 +1,6 @@
 use time::OffsetDateTime;
 
-use crate::{Attachment, PartId, PartTypeId, TbResult, Usage};
+use crate::{Attachment, PartId, PartTypeId, TbResult};
 
 /// This trait defines methods for storing and retrieving attachments.
 #[async_trait::async_trait]
@@ -11,22 +11,11 @@ pub trait AttachmentStore {
     /// Delete an attachment.
     async fn attachment_delete(&mut self, att: Attachment) -> TbResult<Attachment>;
 
-    /// Reset all attachments.
-    async fn attachment_reset_all(&mut self) -> TbResult<usize>;
-
     /// Get all attachments for a given gear and time.
     async fn attachment_get_by_gear_and_time(
         &mut self,
         act_gear: PartId,
         start: OffsetDateTime,
-    ) -> TbResult<Vec<Attachment>>;
-
-    /// Add usage to all attachments for a given gear and time.
-    async fn attachments_add_usage_by_gear_and_time(
-        &mut self,
-        act_gear: PartId,
-        start: OffsetDateTime,
-        usage: &Usage,
     ) -> TbResult<Vec<Attachment>>;
 
     /// Get all attachments for a list of part IDs.

--- a/domain/src/traits/mod.rs
+++ b/domain/src/traits/mod.rs
@@ -13,6 +13,9 @@ pub use activity::*;
 mod attachment;
 pub use attachment::*;
 
+mod usage;
+pub use usage::*;
+
 use crate::UserId;
 
 #[async_trait::async_trait]

--- a/domain/src/traits/mod.rs
+++ b/domain/src/traits/mod.rs
@@ -21,7 +21,7 @@ use crate::UserId;
 #[async_trait::async_trait]
 /// A trait that represents a store for various tb_domain models.
 pub trait Store:
-    Send + TypesStore + PartStore + UserStore + ActivityStore + AttachmentStore
+    Send + TypesStore + PartStore + UserStore + ActivityStore + AttachmentStore + UsageStore
 {
     async fn transaction<'a, R, E, F>(&mut self, callback: F) -> Result<R, E>
     where

--- a/domain/src/traits/part.rs
+++ b/domain/src/traits/part.rs
@@ -1,4 +1,4 @@
-use crate::{Part, PartId, PartTypeId, Person, TbResult, Usage, UsageId, UserId};
+use crate::{Part, PartId, TbResult, UsageId, UserId};
 use time::OffsetDateTime;
 
 #[async_trait::async_trait]
@@ -14,58 +14,6 @@ pub trait PartStore {
     ///
     /// Returns a `Part` object if the part exists, otherwise returns an error.
     async fn partid_get_part(&mut self, pid: PartId) -> TbResult<Part>;
-
-    /// Retrieves the name of a `Part` by its ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - The ID of the part to retrieve the name for.
-    ///
-    /// # Returns
-    ///
-    /// Returns the name of the `Part` if it exists, otherwise returns an error.
-    async fn partid_get_name(&mut self, pid: PartId) -> TbResult<String>;
-
-    /// Retrieves the type of a `Part` by its ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - The ID of the part to retrieve the type for.
-    ///
-    /// # Returns
-    ///
-    /// Returns the type of the `Part` if it exists, otherwise returns an error.
-    async fn partid_get_type(&mut self, pid: PartId) -> TbResult<PartTypeId>;
-
-    /// Retrieves the owner ID of a `Part` by its ID and the user requesting the information.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - The ID of the part to retrieve the owner ID for.
-    /// * `user` - The user requesting the information.
-    ///
-    /// # Returns
-    ///
-    /// Returns the owner ID of the `Part` if it exists and the user has permission to access it, otherwise returns an error.
-    async fn partid_get_ownerid(&mut self, pid: PartId, user: &dyn Person) -> TbResult<UserId>;
-
-    /// Applies usage to a `Part` by its ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - The ID of the part to apply usage to.
-    /// * `usage` - The usage to apply to the part.
-    /// * `start` - The start time of the usage.
-    ///
-    /// # Returns
-    ///
-    /// Returns the updated `Part` object if the part exists and the usage was successfully applied, otherwise returns an error.
-    async fn partid_apply_usage(
-        &mut self,
-        pid: PartId,
-        usage: &Usage,
-        start: OffsetDateTime,
-    ) -> TbResult<Part>;
 
     /// Retrieves all `Part` objects for a given user ID.
     ///
@@ -88,12 +36,19 @@ pub trait PartStore {
     /// # Returns
     ///
     /// Returns the newly created `Part` object if it was successfully created, otherwise returns an error.
-    async fn create_part(
+    async fn part_create(
         &mut self,
         newpart: crate::NewPart,
         createtime: OffsetDateTime,
         usage: UsageId,
     ) -> TbResult<Part>;
+
+    /// updates an existing part
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the part does not exist or there is a store error.
+    async fn part_update(&mut self, part: &Part) -> TbResult<usize>;
 
     /// Changes an existing `Part` object.
     ///

--- a/domain/src/traits/part.rs
+++ b/domain/src/traits/part.rs
@@ -1,4 +1,4 @@
-use crate::{Part, PartId, PartTypeId, Person, TbResult, Usage, UserId};
+use crate::{Part, PartId, PartTypeId, Person, TbResult, Usage, UsageId, UserId};
 use time::OffsetDateTime;
 
 #[async_trait::async_trait]
@@ -78,17 +78,6 @@ pub trait PartStore {
     /// Returns a vector of `Part` objects if the user has parts, otherwise returns an error.
     async fn part_get_all_for_userid(&mut self, uid: &UserId) -> TbResult<Vec<Part>>;
 
-    /// Resets all usages for a given user's `Part` objects.
-    ///
-    /// # Arguments
-    ///
-    /// * `uid` - The ID of the user to reset usages for.
-    ///
-    /// # Returns
-    ///
-    /// Returns a vector of updated `Part` objects if the user has parts and the usages were successfully reset, otherwise returns an error.
-    async fn parts_reset_all_usages(&mut self, uid: UserId) -> TbResult<Vec<Part>>;
-
     /// Creates a new `Part` object.
     ///
     /// # Arguments
@@ -103,6 +92,7 @@ pub trait PartStore {
         &mut self,
         newpart: crate::NewPart,
         createtime: OffsetDateTime,
+        usage: UsageId,
     ) -> TbResult<Part>;
 
     /// Changes an existing `Part` object.

--- a/domain/src/traits/usage.rs
+++ b/domain/src/traits/usage.rs
@@ -1,0 +1,38 @@
+use crate::{TbResult, Usage, UsageId};
+
+#[async_trait::async_trait]
+/// A trait representing a store for `Usage` objects.
+pub trait UsageStore {
+    /// Retrieves a `Usage` by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `uid` - The ID of the Usage to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Usage` object if the Usage exists, otherwise returns an error.
+    async fn read(&mut self, uid: UsageId) -> TbResult<Usage>;
+
+    /// Creates a new `Usage` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `usage` - The new `Usage` object to create.
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created `Usage` object if it was successfully created, otherwise returns an error.
+    async fn create(&mut self, usage: &Usage) -> TbResult<usize>;
+
+    /// Changes an existing `Usage` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `Usage` - The `Usage` object containing the changes to apply.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `Usage` object if it was successfully updated, otherwise returns an error.
+    async fn update(&mut self, usage: Vec<&Usage>) -> TbResult<usize>;
+}

--- a/domain/src/traits/usage.rs
+++ b/domain/src/traits/usage.rs
@@ -26,7 +26,20 @@ pub trait UsageStore {
     /// # Returns
     ///
     /// Returns the updated `Usage` object if it was successfully updated, otherwise returns an error.
-    async fn usage_update(&mut self, usage: Vec<&Usage>) -> TbResult<usize>;
+    async fn usage_update<U>(&mut self, usage: &Vec<U>) -> TbResult<usize>
+    where
+        U: std::borrow::Borrow<Usage> + Sync;
+
+    /// Delete the Usage
+    ///
+    /// # Arguments
+    ///
+    /// * `Usage` - The `Usage` object to delete.
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of deleted objects or returns an error.
+    async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<usize>;
 
     /// Resets all Usages.
     ///

--- a/domain/src/traits/usage.rs
+++ b/domain/src/traits/usage.rs
@@ -3,7 +3,7 @@ use crate::{TbResult, Usage, UsageId};
 #[async_trait::async_trait]
 /// A trait representing a store for `Usage` objects.
 pub trait UsageStore {
-    /// Retrieves a `Usage` by its ID.
+    /// Retrieves or creates a `Usage` by its ID.
     ///
     /// # Arguments
     ///
@@ -11,21 +11,13 @@ pub trait UsageStore {
     ///
     /// # Returns
     ///
-    /// Returns a `Usage` object if the Usage exists, otherwise returns an error.
-    async fn read(&mut self, uid: UsageId) -> TbResult<Usage>;
+    /// Returns the `Usage` object if the Usage exists, an empty new one if not
+    /// Might returns an error from underlying storage system.
+    async fn usage_get(&mut self, uid: UsageId) -> TbResult<Usage>;
 
-    /// Creates a new `Usage` object.
-    ///
-    /// # Arguments
-    ///
-    /// * `usage` - The new `Usage` object to create.
-    ///
-    /// # Returns
-    ///
-    /// Returns the newly created `Usage` object if it was successfully created, otherwise returns an error.
-    async fn create(&mut self, usage: &Usage) -> TbResult<usize>;
-
-    /// Changes an existing `Usage` object.
+    /// Changes an array of `Usage` objects.
+    /// Might delete the Usages on the store if it is all zero
+    /// If a Usage does not exist, it will create it on the store
     ///
     /// # Arguments
     ///
@@ -34,5 +26,12 @@ pub trait UsageStore {
     /// # Returns
     ///
     /// Returns the updated `Usage` object if it was successfully updated, otherwise returns an error.
-    async fn update(&mut self, usage: Vec<&Usage>) -> TbResult<usize>;
+    async fn usage_update(&mut self, usage: Vec<&Usage>) -> TbResult<usize>;
+
+    /// Resets all Usages.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the number of reset parts or an error if the operation fails.
+    async fn usage_reset_all(&mut self) -> TbResult<usize>;
 }

--- a/domain/src/traits/usage.rs
+++ b/domain/src/traits/usage.rs
@@ -39,7 +39,7 @@ pub trait UsageStore {
     /// # Returns
     ///
     /// Returns the number of deleted objects or returns an error.
-    async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<usize>;
+    async fn usage_delete(&mut self, usage: &UsageId) -> TbResult<Usage>;
 
     /// Resets all Usages.
     ///

--- a/frontend/src/Actions/InstallPart.svelte
+++ b/frontend/src/Actions/InstallPart.svelte
@@ -22,8 +22,6 @@
     gear = g;
     part = new Part({
       owner: $user && $user.id,
-      purchase: new Date(),
-      last_used: new Date(),
     });
     disabled = true;
     type = undefined;

--- a/frontend/src/Activities/ActTable.svelte
+++ b/frontend/src/Activities/ActTable.svelte
@@ -147,7 +147,7 @@
     return r.reduce((total, row) => {
       total.add(row);
       return total;
-    }, new Usage({}));
+    }, new Usage());
   };
 </script>
 

--- a/frontend/src/Part/GearCard.svelte
+++ b/frontend/src/Part/GearCard.svelte
@@ -7,8 +7,8 @@
     Row,
     Col,
   } from "@sveltestrap/sveltestrap";
-  import { types, fmtSeconds, fmtDate, fmtNumber } from "../lib/store";
-  import { Part } from "../lib/types";
+  import { types, usages, fmtSeconds, fmtDate, fmtNumber } from "../lib/store";
+  import { Part, Usage } from "../lib/types";
   import { link } from "svelte-spa-router";
 
   export let part: Part;
@@ -16,6 +16,9 @@
 
   let isOpen = false;
   let showLink = false;
+
+  let usage = new Usage();
+  $: if ($usages[part.usage]) usage = $usages[part.usage];
 
   function model(part: Part) {
     if (part.model == "" && part.vendor == "") {
@@ -75,17 +78,15 @@
       {/if}
       you used
       <a href={"/activities/" + part.id} use:link class="param text-reset"
-        >{fmtNumber(part.count)}</a
+        >{fmtNumber(usage.count)}</a
       >
-      times for <span class="param">{fmtSeconds(part.time)}</span> hours.
+      times for <span class="param">{fmtSeconds(usage.time)}</span> hours.
       <p>
         You covered <span class="param"
-          >{fmtNumber(
-            parseFloat(((part.distance || 0) / 1000).toFixed(1)),
-          )}</span
+          >{fmtNumber(parseFloat((usage.distance / 1000).toFixed(1)))}</span
         >
-        km climbing <span class="param">{fmtNumber(part.climb)}</span> and
-        descending <span class="param">{fmtNumber(part.descend)}</span> meters
+        km climbing <span class="param">{fmtNumber(usage.climb)}</span> and
+        descending <span class="param">{fmtNumber(usage.descend)}</span> meters
       </p></CardBody
     >
     <!-- </div> -->

--- a/frontend/src/Part/PartHist.svelte
+++ b/frontend/src/Part/PartHist.svelte
@@ -40,7 +40,7 @@
                 N/A
               {/if}
             </td><td>{att.fmtTime()}</td>
-            <Usage usage={att} ref={att.idx} />
+            <Usage id={att.usage} ref={att.idx} />
           </tr>
         {/each}
       </tbody>

--- a/frontend/src/Part/SubType.svelte
+++ b/frontend/src/Part/SubType.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { DropdownItem } from "@sveltestrap/sveltestrap";
-  import { parts } from "../lib/store";
+  import { parts, usages } from "../lib/store";
   import Usage from "../Usage.svelte";
   import ReplacePart from "../Actions/ReplacePart.svelte";
   import AttachPart from "../Actions/AttachPart.svelte";
@@ -34,7 +34,7 @@
         <th scope="row" class="text-nowrap">
           {"| ".repeat(level)}
           {prefix + " " + type.name}
-          {#if attachments.length > 0 || (part && part.count != att.count)}
+          {#if attachments.length > 0 || (part && $usages[part.usage].count != $usages[att.usage].count)}
             <ShowAll bind:show_hist />
           {/if}
         </th>
@@ -54,7 +54,7 @@
             {/if}
           </td>
           <td> {att.fmtTime()} </td>
-          <Usage usage={part} ref={part.id} />
+          <Usage id={part.usage} ref={part.id} />
           <td>
             <Menu>
               <DropdownItem on:click={() => attachPart(part)}>
@@ -90,7 +90,7 @@
           {/if}
         </td>
         <td> {att.fmtTime()} </td>
-        <Usage usage={att} ref={att.idx} />
+        <Usage id={att.usage} ref={att.idx} />
         <td>
           <Menu>
             <DropdownItem on:click={() => attachPart(part)}

--- a/frontend/src/Spares/SpareType.svelte
+++ b/frontend/src/Spares/SpareType.svelte
@@ -77,7 +77,7 @@
         {part.name}
       </a>
     </td>
-    <Usage usage={part} ref={part.id} />
+    <Usage id={part.usage} ref={part.id} />
     {#if attachee > 0}
       <td>
         {#if part.disposed_at}

--- a/frontend/src/Usage.svelte
+++ b/frontend/src/Usage.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
   import { link } from "svelte-spa-router";
-  import { fmtSeconds, fmtNumber } from "./lib/store";
+  import { usages, fmtSeconds, fmtNumber } from "./lib/store";
   import { Usage } from "./lib/types";
 
-  export let usage: Usage | undefined = undefined;
+  export let id: string | undefined = undefined;
   export let ref: string | number | undefined = undefined;
+
+  let usage = new Usage();
+  $: if (id) usage = $usages[id];
 </script>
 
-{#if usage}
+{#if id}
   <td class="text-end">
     {#if ref}
       <a class="text-reset" use:link href={"/activities/" + ref}>

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -7,6 +7,7 @@ import {
   Type,
   type ActType,
   type User,
+  Usage,
 } from "./types";
 
 export { type Map, filterValues, by } from "./mapable";
@@ -106,18 +107,21 @@ type Summary = {
   parts: Part[];
   attachments: Attachment[];
   activities: Activity[];
+  usages: Usage[];
 };
 
 export function setSummary(data: Summary) {
   parts.setMap(data.parts);
   attachments.setMap(data.attachments);
   activities.setMap(data.activities);
+  usages.setMap(data.usages);
 }
 
 export function updateSummary(data: Summary) {
   parts.updateMap(data.parts);
   attachments.updateMap(data.attachments);
   activities.updateMap(data.activities);
+  usages.updateMap(data.usages);
 }
 
 export let types: { [key: number]: Type };
@@ -132,6 +136,7 @@ export const attachments = mapable(
   (a) => new Attachment(a),
   (a) => a.isEmpty(),
 );
+export const usages = mapable("id", (u) => new Usage(u));
 
 export const state = writable({ show_all_spares: false });
 export const message = writable({

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -66,9 +66,9 @@ export class Part {
     this.id = data.id;
     this.owner = data.owner;
     this.what = data.what;
-    this.name = data.name;
-    this.vendor = data.vendor;
-    this.model = data.model;
+    this.name = data.name || "";
+    this.vendor = data.vendor || "";
+    this.model = data.model || "";
     this.purchase = new Date(data.purchase);
     this.last_used = new Date(data.last_used);
     this.disposed_at = data.disposed_at

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,15 +12,17 @@ import {
 export const maxDate = new Date("2999-12-31");
 
 export class Usage {
-  count?: number;
-  climb?: number;
-  descend?: number;
-  distance?: number;
-  time?: number;
-  duration?: number;
+  id: string;
+  count: number;
+  climb: number;
+  descend: number;
+  distance: number;
+  time: number;
+  duration: number;
 
   constructor(data?: any) {
     if (data) {
+      this.id = data.id;
       this.count = data.count;
       this.climb = data.climb;
       this.descend = data.descend;
@@ -28,6 +30,7 @@ export class Usage {
       this.time = data.time;
       this.duration = data.duration;
     } else {
+      this.id = "";
       this.count = 0;
       this.climb = 0;
       this.descend = 0;
@@ -37,26 +40,17 @@ export class Usage {
     }
   }
 
-  // fill () {
-  //   if (! this.count) this.count = 0;
-  //   if (! this.climb) this.climb = 0;
-  //   if (! this.descend) this.descend = this.climb;
-  //   if (! this.distance) this.distance = 0;
-  //   if (! this.time) this.time = 0;
-  //   if (! this.duration) this.duration = this.time;
-  // }
-
-  add(a: Usage) {
-    this.count = (this.count || 0) + (a.count || 1);
-    this.climb = (this.climb || 0) + (a.climb || 0);
-    this.descend = (this.descend || 0) + (a.descend || a.climb || 0);
-    this.distance = (this.distance || 0) + (a.distance || 0);
-    this.time = (this.time || 0) + (a.time || a.duration || 0);
-    this.duration = (this.duration || 0) + (a.duration || a.time || 0);
+  add(a: Usage | Activity) {
+    this.count += a.count || 1;
+    this.climb += a.climb || 0;
+    this.descend += a.descend || a.climb || 0;
+    this.distance += a.distance || 0;
+    this.time += a.time || a.duration || 0;
+    this.duration += a.duration || a.time || 0;
   }
 }
 
-export class Part extends Usage {
+export class Part {
   id?: number;
   owner: number;
   what: number;
@@ -66,9 +60,9 @@ export class Part extends Usage {
   purchase: Date;
   last_used: Date;
   disposed_at?: Date;
+  usage: string;
 
   constructor(data: any) {
-    super(data);
     this.id = data.id;
     this.owner = data.owner;
     this.what = data.what;
@@ -80,6 +74,7 @@ export class Part extends Usage {
     this.disposed_at = data.disposed_at
       ? new Date(data.disposed_at)
       : undefined;
+    this.usage = data.usage;
   }
 
   async create() {
@@ -120,7 +115,7 @@ export class Part extends Usage {
   }
 }
 
-export class Attachment extends Usage {
+export class Attachment {
   part_id: number;
   attached: Date;
   gear: number;
@@ -129,8 +124,8 @@ export class Attachment extends Usage {
   what: number;
   name: string;
   idx: string;
+  usage: string;
   constructor(data: any) {
-    super(data);
     this.part_id = data.part_id;
     this.attached = new Date(data.attached);
     this.gear = data.gear;
@@ -139,6 +134,7 @@ export class Attachment extends Usage {
     this.what = data.what;
     this.name = data.name;
     this.idx = this.part_id + "/" + this.attached.getTime();
+    this.usage = data.usage;
   }
   fmtTime() {
     let res = fmtDate(this.attached);
@@ -202,7 +198,7 @@ export type User = {
   is_admin: boolean;
 };
 
-export class Activity extends Usage {
+export class Activity {
   id: number;
   /// The athlete
   user_id: number;
@@ -214,15 +210,26 @@ export class Activity extends Usage {
   start: Date;
   /// Which gear did she use?
   gear?: number;
+  count: number;
+  climb?: number;
+  descend?: number;
+  distance?: number;
+  time?: number;
+  duration?: number;
 
   constructor(data: any) {
-    super(data);
     this.id = data.id;
     this.user_id = data.user_id;
     this.what = data.what;
     this.name = data.name;
     this.start = new Date(data.start);
     this.gear = data.gear;
+    this.climb = data.climb;
+    this.descend = data.descend;
+    this.distance = data.distance;
+    this.time = data.time;
+    this.duration = data.duration;
+    this.count = 1;
   }
 
   gearLink(parts: Map<Part>) {


### PR DESCRIPTION
This pull request separates all calculated usage data into its own persisted object. 
The usage entry is referenced by a Uuid which makes handling easy. If there is no Usage object for that Uuid we assume no usage so far. Usage objects are on the fly created when there is an actual use recorded