### PR TITLE
Inline Strava Identifiers

### DIFF
--- a/backend/axum/src/domain/part.rs
+++ b/backend/axum/src/domain/part.rs
@@ -89,7 +89,7 @@ async fn post_part(
     }): Json<NewPart>,
 ) -> Result<(StatusCode, Json<Part>), AppError> {
     let mut store = store.get().await?;
-    let part = Part::create(name, vendor, model, what, purchase, &user, &mut store).await?;
+    let part = Part::create(name, vendor, model, what, None, purchase, &user, &mut store).await?;
     Ok((StatusCode::CREATED, Json(part)))
 }
 

--- a/backend/axum/src/strava/redirect.rs
+++ b/backend/axum/src/strava/redirect.rs
@@ -12,11 +12,12 @@ use axum::{
 use crate::{ApiResult, AxumAdmin, DbPool, RequestUser, error::AppError};
 
 pub(super) async fn redirect_gear(
+    mut user: RequestUser,
     Path(id): Path<i32>,
     State(store): State<DbPool>,
 ) -> Result<Redirect, AppError> {
     let mut store = store.get().await?;
-    let uri = tb_strava::gear::strava_url(id, &mut store)
+    let uri = tb_strava::gear::strava_url(id, &mut user, &mut store)
         .await
         .unwrap_or_else(|_| "/".to_string());
     Ok(Redirect::permanent(&uri))

--- a/backend/axum/src/strava/redirect.rs
+++ b/backend/axum/src/strava/redirect.rs
@@ -24,11 +24,12 @@ pub(super) async fn redirect_gear(
 }
 
 pub(super) async fn redirect_act(
-    Path(id): Path<i32>,
+    user: RequestUser,
+    Path(id): Path<i64>,
     State(store): State<DbPool>,
 ) -> Result<Redirect, AppError> {
     let mut store = store.get().await?;
-    let uri = tb_strava::activity::strava_url(id, &mut store)
+    let uri = tb_strava::activity::strava_url(id, &user, &mut store)
         .await
         .unwrap_or_else(|_| "/".to_string());
     Ok(Redirect::permanent(&uri))

--- a/backend/diesel/migrations/2025-06-18-102221_inline_source/down.sql
+++ b/backend/diesel/migrations/2025-06-18-102221_inline_source/down.sql
@@ -1,0 +1,11 @@
+CREATE TABLE strava_gears (
+    id text PRIMARY KEY,
+    tendabike_id integer NOT NULL,
+    user_id integer NOT NULL REFERENCES strava_users(tendabike_id)
+);
+INSERT into strava_gears (id, tendabike_id, user_id)
+	select source as id, id as tendabike_id, "owner" as user_id from parts where source is not null;
+
+DROP INDEX "parts_source_key";
+ALTER TABLE "parts" DROP COLUMN "source";
+

--- a/backend/diesel/migrations/2025-06-18-102221_inline_source/up.sql
+++ b/backend/diesel/migrations/2025-06-18-102221_inline_source/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "parts" ADD COLUMN "source" text;
+CREATE INDEX "parts_source_key" ON "parts"("source");
+
+update parts
+	SET source = res.id
+	 from (select * from strava_gears) as res
+	 where parts.id = res.tendabike_id
+	;   
+
+DROP TABLE "strava_gears";

--- a/backend/diesel/migrations/2025-06-20-074909_change_activity_id/down.sql
+++ b/backend/diesel/migrations/2025-06-20-074909_change_activity_id/down.sql
@@ -1,0 +1,50 @@
+-- -- This file should undo anything in `up.sql`
+-- ALTER TABLE "activities"
+--     ADD COLUMN "id" serial PRIMARY KEY,
+--     DROP COLUMN "uuid";
+-- CREATE TABLE new_activities(
+--     id serial PRIMARY KEY,
+--     user_id integer NOT NULL,
+--     what integer NOT NULL,
+--     name text NOT NULL,
+--     start timestamp with time zone NOT NULL DEFAULT now(),
+--     duration integer NOT NULL,
+--     time integer,
+--     distance integer,
+--     climb integer,
+--     descend integer,
+--     energy integer,
+--     gear integer,
+--     utc_offset integer NOT NULL DEFAULT 0
+-- );
+-- ALTER SEQUENCE new_activities_id_seq
+--     RESTART WITH 300;
+-- INSERT INTO new_activities(user_id, what, name, start, duration, time, distance, climb, descend, energy, gear, utc_offset)
+-- SELECT
+--     user_id,
+--     what,
+--     name,
+--     START,
+--     duration,
+--     time,
+--     distance,
+--     climb,
+--     descend,
+--     energy,
+--     gear,
+--     utc_offset
+-- FROM
+--     activities;
+-- DROP TABLE activities;
+-- ALTER TABLE new_activities RENAME TO activities;
+ALTER TABLE "activities" RENAME COLUMN "id" TO "id2";
+
+ALTER TABLE "activities" RENAME COLUMN "idalt" TO "id";
+
+ALTER TABLE "activities"
+    DROP CONSTRAINT "activities_pkey",
+    ADD PRIMARY KEY ("id");
+
+ALTER TABLE "activities"
+    DROP COLUMN "id2";
+

--- a/backend/diesel/migrations/2025-06-20-074909_change_activity_id/up.sql
+++ b/backend/diesel/migrations/2025-06-20-074909_change_activity_id/up.sql
@@ -1,0 +1,27 @@
+-- ALTER TABLE "activities"
+--     ADD COLUMN "uuid" uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+--     DROP COLUMN "id";
+ALTER TABLE "activities"
+    ADD COLUMN "id2" bigint;
+
+UPDATE
+    activities
+SET
+    id2 = res.id
+FROM (
+    SELECT
+        *
+    FROM
+        strava_activities) AS res
+WHERE
+    activities.id = res.tendabike_id;
+
+ALTER TABLE "activities"
+    DROP CONSTRAINT "activities_pkey",
+    ADD PRIMARY KEY ("id2");
+
+ALTER TABLE "activities"
+    DROP COLUMN "id";
+
+ALTER TABLE "activities" RENAME COLUMN "id2" TO "id";
+

--- a/backend/diesel/migrations/2025-06-20-173530_remove_user_last_activity/down.sql
+++ b/backend/diesel/migrations/2025-06-20-173530_remove_user_last_activity/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE strava_users
+    ADD COLUMN last_activity bigint DEFAULT 0;
+

--- a/backend/diesel/migrations/2025-06-20-173530_remove_user_last_activity/up.sql
+++ b/backend/diesel/migrations/2025-06-20-173530_remove_user_last_activity/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE strava_users
+    DROP COLUMN last_activity;
+

--- a/backend/diesel/src/store/schema.rs
+++ b/backend/diesel/src/store/schema.rs
@@ -23,6 +23,7 @@ table! {
         last_used -> Timestamptz,
         disposed_at -> Nullable<Timestamptz>,
         usage -> Uuid,
+        source -> Nullable<Text>
     }
 }
 

--- a/backend/diesel/src/store/schema.rs
+++ b/backend/diesel/src/store/schema.rs
@@ -85,4 +85,21 @@ table! {
     }
 }
 
+table! {
+    activities(id) {
+        user_id -> Int4,
+        what -> Int4,
+        name -> Text,
+        start -> Timestamptz,
+        duration -> Int4,
+        time -> Nullable<Int4>,
+        distance -> Nullable<Int4>,
+        climb -> Nullable<Int4>,
+        descend -> Nullable<Int4>,
+        energy -> Nullable<Int4>,
+        gear -> Nullable<Int4>,
+        utc_offset -> Int4,
+        id -> Int8,
+    }
+}
 allow_tables_to_appear_in_same_query!(attachments, parts, users,);

--- a/backend/diesel/src/stravastore.rs
+++ b/backend/diesel/src/stravastore.rs
@@ -1,4 +1,4 @@
-use diesel::{prelude::*, sql_query};
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use crate::{AsyncDieselConn, into_domain, option_into, vec_into};
@@ -253,28 +253,6 @@ impl tb_strava::StravaStore for AsyncDieselConn {
         use schema::strava_events::dsl::*;
 
         diesel::delete(strava_events.filter(owner_id.eq(i32::from(*user))))
-            .execute(self)
-            .await
-            .map_err(into_domain)
-    }
-
-    async fn stravaid_lock(&mut self, user_id: &StravaId) -> TbResult<bool> {
-        use diesel::sql_types::Bool;
-        #[derive(QueryableByName, Debug)]
-        struct Lock {
-            #[diesel(sql_type = Bool)]
-            #[diesel(column_name = pg_try_advisory_lock)]
-            lock: bool,
-        }
-        let lock: bool = sql_query(format!("SELECT pg_try_advisory_lock({});", user_id))
-            .get_result::<Lock>(self)
-            .await?
-            .lock;
-        Ok(lock)
-    }
-
-    async fn stravaid_unlock(&mut self, id: &StravaId) -> TbResult<usize> {
-        sql_query(format!("SELECT pg_advisory_unlock({});", id))
             .execute(self)
             .await
             .map_err(into_domain)

--- a/backend/diesel/src/stravastore.rs
+++ b/backend/diesel/src/stravastore.rs
@@ -11,7 +11,6 @@ mod schema;
 pub struct DbStravaUser {
     id: i32,
     tendabike_id: i32,
-    last_activity: i64,
     refresh_token: Option<String>,
 }
 
@@ -20,13 +19,11 @@ impl From<StravaUser> for DbStravaUser {
         let StravaUser {
             id,
             tendabike_id,
-            last_activity,
             refresh_token,
         } = value;
         Self {
             id: id.into(),
             tendabike_id: tendabike_id.into(),
-            last_activity,
             refresh_token,
         }
     }
@@ -36,13 +33,11 @@ impl From<DbStravaUser> for StravaUser {
         let DbStravaUser {
             id,
             tendabike_id,
-            last_activity,
             refresh_token,
         } = value;
         Self {
             id: id.into(),
             tendabike_id: tendabike_id.into(),
-            last_activity,
             refresh_token,
         }
     }
@@ -289,19 +284,6 @@ impl tb_strava::StravaStore for AsyncDieselConn {
             .await
             .map_err(into_domain)
             .map(Into::into)
-    }
-
-    async fn stravauser_update_last_activity(
-        &mut self,
-        user: &StravaId,
-        time: i64,
-    ) -> TbResult<()> {
-        use schema::strava_users::dsl::*;
-        diesel::update(strava_users.find(i32::from(*user)))
-            .set(last_activity.eq(time))
-            .execute(self)
-            .await?;
-        Ok(())
     }
 
     async fn stravaid_update_token(

--- a/backend/diesel/src/stravastore/schema.rs
+++ b/backend/diesel/src/stravastore/schema.rs
@@ -25,7 +25,6 @@ table! {
     strava_users (id) {
         id -> Int4,
         tendabike_id -> Int4,
-        last_activity -> Int8,
         refresh_token -> Nullable<Text>,
     }
 }

--- a/backend/diesel/src/stravastore/schema.rs
+++ b/backend/diesel/src/stravastore/schema.rs
@@ -9,14 +9,6 @@ table! {
 }
 
 table! {
-    strava_gears (id) {
-        id -> Text,
-        tendabike_id -> Int4,
-        user_id -> Int4,
-    }
-}
-
-table! {
     strava_events (id) {
         id -> Nullable<Int4>,
         object_type -> Text,
@@ -47,4 +39,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(strava_activities, strava_events, strava_gears, strava_users,);
+allow_tables_to_appear_in_same_query!(strava_activities, strava_events, strava_users,);

--- a/backend/domain/src/entities/part.rs
+++ b/backend/domain/src/entities/part.rs
@@ -31,6 +31,7 @@
 //!
 //! Finally, this module defines the `NewPart` type, which is used to create new parts in the database.
 
+#![allow(clippy::too_many_arguments)]
 use newtype_derive::*;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -66,6 +67,7 @@ pub struct Part {
     pub disposed_at: Option<OffsetDateTime>,
     /// the usage tracker
     pub usage: UsageId,
+    pub source: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -252,6 +254,7 @@ impl Part {
         vendor: String,
         model: String,
         what: PartTypeId,
+        source: Option<String>,
         purchase: OffsetDateTime,
         user: &dyn Person,
         store: &mut impl PartStore,
@@ -266,6 +269,7 @@ impl Part {
                 vendor,
                 model,
                 purchase,
+                source,
                 UsageId::new(),
                 user.get_id(),
             )

--- a/backend/domain/src/traits/activity.rs
+++ b/backend/domain/src/traits/activity.rs
@@ -1,6 +1,6 @@
 use time::OffsetDateTime;
 
-use crate::{ActTypeId, Activity, ActivityId, NewActivity, PartId, Person, TbResult, UserId};
+use crate::{ActTypeId, Activity, ActivityId, PartId, Person, TbResult, UserId};
 
 // A trait for storing and retrieving activities.
 /// A trait defining the methods for storing and retrieving activities.
@@ -10,12 +10,12 @@ pub trait ActivityStore {
     ///
     /// # Arguments
     ///
-    /// * `act` - A reference to a `NewActivity` struct containing the details of the new activity.
+    /// * `act` - A reference to a `Activity` struct containing the details of the new activity.
     ///
     /// # Returns
     ///
     /// Returns a `Result` containing the newly created `Activity` or an error if the operation fails.
-    async fn activity_create(&mut self, act: &NewActivity) -> TbResult<Activity>;
+    async fn activity_create(&mut self, act: Activity) -> TbResult<Activity>;
 
     /// Retrieves an activity by its ID.
     ///
@@ -26,19 +26,18 @@ pub trait ActivityStore {
     /// # Returns
     ///
     /// Returns a `Result` containing the retrieved `Activity` or an error if the operation fails.
-    async fn activity_read_by_id(&mut self, aid: ActivityId) -> TbResult<Activity>;
+    async fn activity_read_by_id(&mut self, aid: ActivityId) -> TbResult<Option<Activity>>;
 
     /// Updates an existing activity.
     ///
     /// # Arguments
     ///
-    /// * `aid` - The ID of the activity to update.
-    /// * `act` - A reference to a `NewActivity` struct containing the updated details of the activity.
+    /// * `act` - A reference to a `Activity` struct containing the updated details of the activity.
     ///
     /// # Returns
     ///
     /// Returns a `Result` containing the updated `Activity` or an error if the operation fails.
-    async fn activity_update(&mut self, aid: ActivityId, act: &NewActivity) -> TbResult<Activity>;
+    async fn activity_update(&mut self, act: Activity) -> TbResult<Activity>;
 
     /// Deletes an activity by its ID.
     ///

--- a/backend/domain/src/traits/part.rs
+++ b/backend/domain/src/traits/part.rs
@@ -44,6 +44,7 @@ pub trait PartStore {
         vendor: String,
         model: String,
         purchase: OffsetDateTime,
+        source: Option<String>,
         usage: UsageId,
         owner: UserId,
     ) -> TbResult<Part>;
@@ -54,4 +55,19 @@ pub trait PartStore {
     ///
     /// This function will return an error if the part does not exist or there is a store error.
     async fn part_update(&mut self, part: Part) -> TbResult<Part>;
+
+    /// Returns the PartId associated with the given Strava gear ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `strava_id` - The Strava ID of the gear.
+    ///
+    /// # Returns
+    ///
+    /// The PartId associated with the given Strava gear ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the PartId cannot be retrieved from the database.
+    async fn partid_get_by_source(&mut self, strava_id: &str) -> TbResult<Option<PartId>>;
 }

--- a/backend/strava/src/activity.rs
+++ b/backend/strava/src/activity.rs
@@ -68,12 +68,8 @@ impl StravaActivity {
             kilojoules,
             gear_id,
         } = self;
-        let mut offset = utc_offset as i32;
-        if offset % 1800 != 0 {
-            warn!("rounding utc_offset {offset} for activity {id}");
-            offset = offset + 900 - (offset + 900) % 1800;
-        }
-        let offset = UtcOffset::from_whole_seconds(offset).context("Utc Offset invalid")?;
+        let offset =
+            UtcOffset::from_whole_seconds(utc_offset as i32).context("Utc Offset invalid")?;
         let what = Self::get_type(&type_)?;
         let gear = match gear_id {
             // cannot use map due to async closure

--- a/backend/strava/src/activity.rs
+++ b/backend/strava/src/activity.rs
@@ -1,7 +1,7 @@
 // This file contains the implementation of the StravaActivity struct and its methods.
 // StravaActivity is a struct that represents an activity from Strava API.
 // It has fields that represent the activity's properties such as id, type, name, start date, elapsed time, moving time, distance, total elevation gain, average watts, and gear id.
-// The struct also has a method called into_tb that converts the StravaActivity into a NewActivity struct which is used to create a new activity in the Tendabike API.
+// The struct also has a method called into_tb that converts the StravaActivity into a Activity struct which is used to create a new activity in the Tendabike API.
 // The struct also has a method called what that maps Strava workout type strings to Tendabike types.
 // The file imports the OffsetDateTime struct from the time crate.
 // The file also has two comments that indicate the beginning and end of a code block.
@@ -39,7 +39,7 @@ pub(crate) struct StravaActivity {
 }
 
 impl StravaActivity {
-    /// Converts a StravaActivity into a NewActivity struct which is used to create a new activity in the Tendabike API.
+    /// Converts a StravaActivity into a Activity struct which is used to create a new activity in the Tendabike API.
     ///
     /// # Arguments
     ///
@@ -49,35 +49,50 @@ impl StravaActivity {
     ///
     /// # Returns
     ///
-    /// A Result containing a NewActivity struct if the conversion was successful, or an error if it failed.
-    async fn into_tb(
+    /// A Result containing a Activity struct if the conversion was successful, or an error if it failed.
+    async fn into_activity(
         self,
         user: &mut impl StravaPerson,
         store: &mut impl StravaStore,
-    ) -> TbResult<NewActivity> {
-        let mut offset = self.utc_offset as i32;
+    ) -> TbResult<Activity> {
+        let StravaActivity {
+            id,
+            type_,
+            name,
+            start_date,
+            utc_offset,
+            elapsed_time,
+            moving_time,
+            distance,
+            total_elevation_gain,
+            kilojoules,
+            gear_id,
+        } = self;
+        let mut offset = utc_offset as i32;
         if offset % 1800 != 0 {
+            warn!("rounding utc_offset {offset} for activity {id}");
             offset = offset + 900 - (offset + 900) % 1800;
-            warn!("rounding utc_offset for {self:?} to {offset}");
         }
         let offset = UtcOffset::from_whole_seconds(offset).context("Utc Offset invalid")?;
-        let what = self.what()?;
-        let gear = match self.gear_id {
-            Some(x) => Some(gear::strava_to_tb(x, user, store).await?),
+        let what = Self::get_type(&type_)?;
+        let gear = match gear_id {
+            // cannot use map due to async closure
+            Some(x) => Some(gear::into_partid(x, user, store).await?),
             None => None,
         };
-        Ok(NewActivity {
+        Ok(Activity {
+            id: id.into(),
             what,
             gear,
             user_id: user.tb_id(),
-            name: self.name,
-            start: self.start_date.to_offset(offset),
-            duration: self.elapsed_time,
-            time: Some(self.moving_time),
-            distance: Some(self.distance.round() as i32),
-            climb: Some(self.total_elevation_gain.round() as i32),
+            name,
+            start: start_date.to_offset(offset),
+            duration: elapsed_time,
+            time: Some(moving_time),
+            distance: Some(distance.round() as i32),
+            climb: Some(total_elevation_gain.round() as i32),
             descend: None,
-            energy: self.kilojoules.map(|e| e.round() as i32),
+            energy: kilojoules.map(|e| e.round() as i32),
         })
     }
 
@@ -90,9 +105,7 @@ impl StravaActivity {
     /// # Returns
     ///
     /// A Result containing an ActTypeId if the mapping was successful, or an error if it failed.
-    fn what(&self) -> TbResult<ActTypeId> {
-        let t = self.type_.as_str();
-
+    fn get_type(t: &str) -> TbResult<ActTypeId> {
         Ok(match t {
             "Ride" => 1,
             "VirtualRide" => 5,
@@ -136,9 +149,7 @@ impl StravaActivity {
         }
         .into())
     }
-}
 
-impl StravaActivity {
     /// Sends the activity to Tendabike API.
     ///
     /// # Arguments
@@ -152,42 +163,22 @@ impl StravaActivity {
     /// A Result containing a Summary if the sending was successful, or an error if it failed.
     pub(crate) async fn send_to_tb(
         self,
-        migrate: bool,
         user: &mut impl StravaPerson,
         store: &mut impl StravaStore,
     ) -> TbResult<Summary> {
-        let strava_id = self.id;
-        let tb = self.into_tb(user, store).await?;
-        store
-            .transaction(|store| {
-                async {
-                    let tb_id = store.strava_activity_get_tbid(strava_id).await?;
-                    let res;
-                    if let Some(tb_id) = tb_id {
-                        res = match migrate {
-                            true => tb_id.migrate(tb, user, store).await,
-                            _ => tb_id.update(tb, user, store).await,
-                        }?;
-                    } else {
-                        res = Activity::create(&tb, user, store).await?;
-                        let new_id = res.activities[0].id;
-                        store
-                            .strava_activity_new(strava_id, tb.user_id, new_id)
-                            .await?;
-                    }
+        let activity = self.into_activity(user, store).await?;
 
-                    Ok(res)
-                }
-                .scope_boxed()
-            })
-            .await
+        activity.upsert(user, store).await
     }
 }
 
-pub async fn strava_url(act: i32, store: &mut impl StravaStore) -> TbResult<String> {
-    let g = store.strava_activitid_get_by_tbid(act).await?;
-
-    Ok(format!("https://strava.com/activities/{}", &g))
+pub async fn strava_url(
+    act: i64,
+    user: &impl StravaPerson,
+    store: &mut impl StravaStore,
+) -> TbResult<String> {
+    let g = ActivityId::new(act).read(user, store).await?;
+    Ok(format!("https://strava.com/activities/{}", g.id))
 }
 
 pub async fn upsert_activity(
@@ -198,22 +189,13 @@ pub async fn upsert_activity(
     let act: StravaActivity = user
         .request_json(&format!("/activities/{}", id), store)
         .await?;
-    act.send_to_tb(false, user, store).await
+    act.send_to_tb(user, store).await
 }
 
 pub(crate) async fn delete_activity(
-    act_id: i64,
+    act: i64,
     user: &impl StravaPerson,
     store: &mut impl StravaStore,
 ) -> TbResult<Summary> {
-    let tid = store.strava_activity_get_activityid(act_id).await?;
-    let mut res = Summary::default();
-    if let Some(tid) = tid {
-        // first delete the tendabike activity
-        res = tid.delete(user, store).await?;
-        // now delete the reference to the strava activity
-        // if this fails we end up with an orphaned entry in the strava_activities table, which should not be a problem in practice
-        store.strava_activity_delete(act_id).await?;
-    }
-    Ok(res)
+    ActivityId::new(act).delete(user, store).await
 }

--- a/backend/strava/src/activity.rs
+++ b/backend/strava/src/activity.rs
@@ -162,8 +162,6 @@ impl StravaActivity {
             .transaction(|store| {
                 async {
                     let tb_id = store.strava_activity_get_tbid(strava_id).await?;
-                    let time = tb.start.unix_timestamp();
-
                     let res;
                     if let Some(tb_id) = tb_id {
                         res = match migrate {
@@ -177,11 +175,6 @@ impl StravaActivity {
                             .strava_activity_new(strava_id, tb.user_id, new_id)
                             .await?;
                     }
-
-                    user.strava_id()
-                        .update_last(time, store)
-                        .await
-                        .context("unable to update user")?;
 
                     Ok(res)
                 }

--- a/backend/strava/src/event.rs
+++ b/backend/strava/src/event.rs
@@ -201,7 +201,7 @@ impl Event {
                 trace!("processing sync event at {}", start);
                 for a in acts {
                     start = std::cmp::max(start, a.start_date.unix_timestamp());
-                    let ps = a.send_to_tb(self.object_id != 0, user, store).await?;
+                    let ps = a.send_to_tb(user, store).await?;
                     self.setdate(start, store).await?;
                     summary = summary + ps;
                 }

--- a/backend/strava/src/gear.rs
+++ b/backend/strava/src/gear.rs
@@ -45,7 +45,7 @@ impl StravaGear {
 ///
 /// If it does not exist create it at tb
 /// None will return None
-pub(crate) async fn strava_to_tb(
+pub(crate) async fn into_partid(
     strava_id: String,
     user: &mut impl StravaPerson,
     store: &mut impl StravaStore,

--- a/backend/strava/src/traits.rs
+++ b/backend/strava/src/traits.rs
@@ -209,36 +209,6 @@ pub trait StravaStore: tb_domain::Store + Send {
     ///
     /// Returns an error if the event count cannot be retrieved.
     async fn strava_events_delete_for_user(&mut self, user: &StravaId) -> TbResult<usize>;
-
-    /// Locks a Strava ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `user_id` - The Strava ID to lock.
-    ///
-    /// # Returns
-    ///
-    /// `true` if the lock was successful, `false` otherwise.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the lock cannot be acquired.
-    async fn stravaid_lock(&mut self, user_id: &StravaId) -> TbResult<bool>;
-
-    /// Unlocks a Strava ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The Strava ID to unlock.
-    ///
-    /// # Returns
-    ///
-    /// The number of rows affected by the unlock operation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the unlock operation fails.
-    async fn stravaid_unlock(&mut self, id: &StravaId) -> TbResult<usize>;
 }
 
 #[async_trait]

--- a/backend/strava/src/traits.rs
+++ b/backend/strava/src/traits.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
 use crate::{StravaId, StravaUser, event::Event};
-use tb_domain::{ActivityId, PartId, Person, TbResult, UserId};
+use tb_domain::{ActivityId, Person, TbResult, UserId};
 
 #[async_trait]
 pub trait StravaStore: tb_domain::Store + Send {
@@ -25,37 +25,6 @@ pub trait StravaStore: tb_domain::Store + Send {
     ///
     /// Returns an error if the user ID cannot be retrieved from the database.
     async fn stravaid_get_user_id(&mut self, who: i32) -> TbResult<i32>;
-
-    /// Returns the PartId associated with the given Strava gear ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `strava_id` - The Strava ID of the gear.
-    ///
-    /// # Returns
-    ///
-    /// The PartId associated with the given Strava gear ID.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the PartId cannot be retrieved from the database.
-    async fn strava_gear_get_tbid(&mut self, strava_id: &str) -> TbResult<Option<PartId>>;
-
-    /// Returns the name of the gear associated with the given Strava gear ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `gear` - The Strava ID of the gear.
-    ///
-    /// # Returns
-    ///
-    /// The name of the gear associated with the given Strava gear ID.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the name cannot be retrieved from the database.
-    async fn strava_gearid_get_name(&mut self, gear: i32) -> TbResult<String>;
-
     /// Returns the ActivityId associated with the given Strava activity ID.
     ///
     /// # Arguments
@@ -134,24 +103,6 @@ pub trait StravaStore: tb_domain::Store + Send {
     /// Returns an error if the ActivityId cannot be retrieved from the database.
     async fn strava_activity_get_activityid(&mut self, act_id: i64)
     -> TbResult<Option<ActivityId>>;
-
-    /// Creates a new Strava gear with the given Strava ID, PartId, and user ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `strava_id` - The Strava ID of the gear.
-    /// * `tbid` - The PartId associated with the gear.
-    /// * `user` - The user ID associated with the gear.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the gear cannot be created.
-    async fn strava_gear_new(
-        &mut self,
-        strava_id: String,
-        tbid: PartId,
-        user: UserId,
-    ) -> TbResult<()>;
 
     /// Deletes the Strava event with the given event ID.
     ///

--- a/backend/strava/src/traits.rs
+++ b/backend/strava/src/traits.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
 use crate::{StravaId, StravaUser, event::Event};
-use tb_domain::{ActivityId, Person, TbResult, UserId};
+use tb_domain::{Person, TbResult, UserId};
 
 #[async_trait]
 pub trait StravaStore: tb_domain::Store + Send {
@@ -25,84 +25,6 @@ pub trait StravaStore: tb_domain::Store + Send {
     ///
     /// Returns an error if the user ID cannot be retrieved from the database.
     async fn stravaid_get_user_id(&mut self, who: i32) -> TbResult<i32>;
-    /// Returns the ActivityId associated with the given Strava activity ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `strava_id` - The Strava ID of the activity.
-    ///
-    /// # Returns
-    ///
-    /// The ActivityId associated with the given Strava activity ID.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the ActivityId cannot be retrieved from the database.
-    async fn strava_activity_get_tbid(&mut self, strava_id: i64) -> TbResult<Option<ActivityId>>;
-
-    /// Creates a new Strava activity with the given Strava ID and user ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `strava_id` - The Strava ID of the activity.
-    /// * `uid` - The user ID associated with the activity.
-    /// * `new_id` - The new ActivityId to assign to the activity.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the activity cannot be created.
-    async fn strava_activity_new(
-        &mut self,
-        strava_id: i64,
-        uid: UserId,
-        new_id: ActivityId,
-    ) -> TbResult<()>;
-
-    /// Returns the Strava activity ID associated with the given ActivityId.
-    ///
-    /// # Arguments
-    ///
-    /// * `act` - The ActivityId of the activity.
-    ///
-    /// # Returns
-    ///
-    /// The Strava activity ID associated with the given ActivityId.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the Strava activity ID cannot be retrieved from the database.
-    async fn strava_activitid_get_by_tbid(&mut self, act: i32) -> TbResult<i64>;
-
-    /// Deletes the Strava activity with the given activity ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `act_id` - The ID of the activity to delete.
-    ///
-    /// # Returns
-    ///
-    /// The number of rows affected by the delete operation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the activity cannot be deleted.
-    async fn strava_activity_delete(&mut self, act_id: i64) -> TbResult<usize>;
-
-    /// Returns the ActivityId associated with the given Strava activity ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `act_id` - The Strava ID of the activity.
-    ///
-    /// # Returns
-    ///
-    /// The ActivityId associated with the given Strava activity ID.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the ActivityId cannot be retrieved from the database.
-    async fn strava_activity_get_activityid(&mut self, act_id: i64)
-    -> TbResult<Option<ActivityId>>;
 
     /// Deletes the Strava event with the given event ID.
     ///

--- a/backend/strava/src/traits.rs
+++ b/backend/strava/src/traits.rs
@@ -236,19 +236,6 @@ pub trait StravaStore: tb_domain::Store + Send {
     /// Returns an error if the user cannot be created.
     async fn stravauser_new(&mut self, user: StravaUser) -> TbResult<StravaUser>;
 
-    /// Updates the last activity time for a Strava user.
-    ///
-    /// # Arguments
-    ///
-    /// * `user` - The Strava user to update.
-    /// * `time` - The new last activity time.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the user cannot be updated.
-    async fn stravauser_update_last_activity(&mut self, user: &StravaId, time: i64)
-    -> TbResult<()>;
-
     /// Updates the access token for a Strava user.
     ///
     /// # Arguments

--- a/backend/strava/src/user.rs
+++ b/backend/strava/src/user.rs
@@ -153,7 +153,7 @@ impl StravaUser {
 
         let mut parts = Vec::new();
         for gear in ath.bikes.into_iter().chain(ath.shoes) {
-            parts.push(gear::strava_to_tb(gear.id, user, store).await?);
+            parts.push(gear::into_partid(gear.id, user, store).await?);
         }
 
         Ok(parts)

--- a/backend/strava/src/user.rs
+++ b/backend/strava/src/user.rs
@@ -21,19 +21,6 @@ impl StravaId {
         store.stravauser_get_by_stravaid(self).await
     }
 
-    /// store last activity time for the user
-    pub(crate) async fn update_last(
-        &self,
-        time: i64,
-        store: &mut impl StravaStore,
-    ) -> TbResult<i64> {
-        // if self.last_activity >= time {
-        //     return Ok(self.last_activity);
-        // }
-        store.stravauser_update_last_activity(self, time).await?;
-        Ok(time)
-    }
-
     /// update the refresh token for the user
     ///
     /// sets a five minute buffer for the access token
@@ -50,13 +37,7 @@ impl StravaId {
     async fn disable(self, store: &mut impl StravaStore) -> TbResult<()> {
         let id = self;
         info!("disabling user {}", id);
-        let user = self
-            .read(store)
-            .await?
-            .ok_or(Error::NotFound("StravaUser not found".to_string()))?;
-        event::insert_sync(id, user.last_activity, false, store)
-            .await
-            .context(format!("Could not insert sync for user: {:?}", id))?;
+
         store.stravaid_update_token(id, None).await?;
         Ok(())
     }
@@ -69,8 +50,6 @@ pub struct StravaUser {
     pub id: StravaId,
     /// the corresponding tendabike user id
     pub tendabike_id: UserId,
-    /// the time of the latest activity we have processed
-    pub last_activity: i64,
     /// the refresh token to get a new access token from Strava
     pub refresh_token: Option<String>,
 }


### PR DESCRIPTION
Parts have am optional source field storing the strava part id.

Activities use the strava id as the primary key. This requires that all activities come from strava. Therefore the post message is removed