### PR TITLE
Set color of the View Bike button to the same as the OK button

### DIFF
--- a/frontend/src/Part/MainCard.svelte
+++ b/frontend/src/Part/MainCard.svelte
@@ -18,8 +18,7 @@
     <a
       href="/part/{part.id}"
       use:link
-      class="badge badge-secondary text-decoration-none"
-      style="color:#9FA4FA;"
+      class="badge text-bg-light text-decoration-none"
       title={"View " + $category.name.toLowerCase() + " details"}
     >
       <PlanBadge {planlist} />

--- a/frontend/src/Part/MainCard.svelte
+++ b/frontend/src/Part/MainCard.svelte
@@ -19,6 +19,7 @@
       href="/part/{part.id}"
       use:link
       class="badge badge-secondary text-decoration-none"
+      style="color:#9FA4FA;"
       title={"View " + $category.name.toLowerCase() + " details"}
     >
       <PlanBadge {planlist} />


### PR DESCRIPTION
I always search for the button to actually look at the details of a bike. It has very little contrast. This PR set the color of the arrow to the same color as the OK button

Before:
<img width="95" height="71" alt="Screenshot 2025-09-07 at 21 10 36" src="https://github.com/user-attachments/assets/0adb9efc-e582-4775-99fd-bdf69a9ab90f" />

After:
<img width="93" height="71" alt="Screenshot 2025-09-07 at 21 10 26" src="https://github.com/user-attachments/assets/bc63db79-b2de-49d9-891e-c8e06445b925" />

> [!NOTE]  
> I did not run the project, but adapted the HTML in the browser Dev tools and copied it to the code
